### PR TITLE
Wrap create_dummy_files in main guard

### DIFF
--- a/generate_dummy_files.py
+++ b/generate_dummy_files.py
@@ -178,4 +178,5 @@ def create_dummy_files(num_files=NUM_FILES, output_dir=OUTPUT_DIR):
     if ENABLE_LOGGING:
         logging.info(f"{num_files} dummy files created in '{output_dir}' directory.")
 
-create_dummy_files()
+if __name__ == "__main__":
+    create_dummy_files()


### PR DESCRIPTION
## Summary
- prevent execution during import by wrapping `create_dummy_files()` in a main guard

## Testing
- `python3 -m py_compile generate_dummy_files.py`


------
https://chatgpt.com/codex/tasks/task_e_686931baf0448331a26bd24ca22ce9af