### PR TITLE
Remove unused io import

### DIFF
--- a/generate_dummy_files.py
+++ b/generate_dummy_files.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from PIL import Image
 from fpdf import FPDF
 import zipfile
-import io
 import csv
 import json
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary
- drop the unused `io` module from imports

## Testing
- `python3 -m py_compile generate_dummy_files.py`

------
https://chatgpt.com/codex/tasks/task_e_686931f44fb083319d962cfe1330af51